### PR TITLE
Tutorial Updates

### DIFF
--- a/tutorials/docs/bt_actions.rst
+++ b/tutorials/docs/bt_actions.rst
@@ -98,9 +98,9 @@ If you haven't done yet, clone in your workspace and build the |PN| `examples <h
       set predicate (is_assembly_zone assembly_zone)
       set predicate (is_recharge_zone recharge_zone)
               
-      set predicate (piece_at wheel_1 assembly_zone)
-      set predicate (piece_at body_car_1 assembly_zone)
-      set predicate (piece_at steering_wheel_1 assembly_zone)
+      set predicate (piece_at wheel_1 wheels_zone)
+      set predicate (piece_at body_car_1 body_car_zone)
+      set predicate (piece_at steering_wheel_1 steering_wheels_zone)
        
       set predicate (piece_is_wheel wheel_1)
       set predicate (piece_is_body_car body_car_1)

--- a/tutorials/docs/bt_actions.rst
+++ b/tutorials/docs/bt_actions.rst
@@ -68,46 +68,46 @@ If you haven't done yet, clone in your workspace and build the |PN| `examples <h
 * In the |PN| terminal shell, copy and paste the next commands to init the knowledge of the system and set the goal:
 
    .. code-block:: lisp
+   
+      set instance r2d2 robot
+      
+      set instance wheels_zone zone
+      set instance steering_wheels_zone zone
+      set instance body_car_zone zone
+      set instance assembly_zone zone
+      
+      set instance wheel_1 piece
+      set instance body_car_1 piece
+      set instance steering_wheel_1 piece
+      
+      set instance wheel_2 piece
+      set instance body_car_2 piece
+      set instance steering_wheel_2 piece
+       
+      set instance wheel_3 piece
+      set instance body_car_3 piece
+      set instance steering_wheel_3 piece
+       
+      set instance car_1 car
+      set instance car_2 car
+      set instance car_3 car
 
-       > set instance r2d2 robot
-       
-       > set instance wheels_zone zone
-       > set instance steering_wheels_zone zone
-       > set instance body_car_zone zone
-       > set instance assembly_zone zone
-       
-       > set instance wheel_1 piece
-       > set instance body_car_1 piece
-       > set instance steering_wheel_1 piece
-       
-       > set instance wheel_2 piece
-       > set instance body_car_2 piece
-       > set instance steering_wheel_2 piece
-       
-       > set instance wheel_3 piece
-       > set instance body_car_3 piece
-       > set instance steering_wheel_3 piece
-       
-       > set instance car_1 car
-       > set instance car_2 car
-       > set instance car_3 car
-       
-       > set predicate (robot_at r2d2 wheels_zone)
-       > set predicate (is_assembly_zone assembly_zone)
+      set predicate (robot_at r2d2 wheels_zone)
+      set predicate (is_assembly_zone assembly_zone)
               
-       > set predicate (piece_at wheel_1 assembly_zone)
-       > set predicate (piece_at body_car_1 assembly_zone)
-       > set predicate (piece_at steering_wheel_1 assembly_zone)
+      set predicate (piece_at wheel_1 assembly_zone)
+      set predicate (piece_at body_car_1 assembly_zone)
+      set predicate (piece_at steering_wheel_1 assembly_zone)
        
-       > set predicate (piece_is_wheel wheel_1)
-       > set predicate (piece_is_body_car body_car_1)
-       > set predicate (piece_is_steering_wheel steering_wheel_1)
-       > set predicate (piece_not_used wheel_1)
-       > set predicate (piece_not_used body_car_1)
-       > set predicate (piece_not_used steering_wheel_1)
+      set predicate (piece_is_wheel wheel_1)
+      set predicate (piece_is_body_car body_car_1)
+      set predicate (piece_is_steering_wheel steering_wheel_1)
+      set predicate (piece_not_used wheel_1)
+      set predicate (piece_not_used body_car_1)
+      set predicate (piece_not_used steering_wheel_1)
        
-       > set goal (and(car_assembled car_1))
-       > run
+      set goal (and(car_assembled car_1))
+      run
 
 2- Using Behavior Trees
 -----------------------

--- a/tutorials/docs/bt_actions.rst
+++ b/tutorials/docs/bt_actions.rst
@@ -75,6 +75,7 @@ If you haven't done yet, clone in your workspace and build the |PN| `examples <h
       set instance steering_wheels_zone zone
       set instance body_car_zone zone
       set instance assembly_zone zone
+      set instance recharge_zone zone
       
       set instance wheel_1 piece
       set instance body_car_1 piece
@@ -92,8 +93,10 @@ If you haven't done yet, clone in your workspace and build the |PN| `examples <h
       set instance car_2 car
       set instance car_3 car
 
+      set predicate (robot_available r2d2)
       set predicate (robot_at r2d2 wheels_zone)
       set predicate (is_assembly_zone assembly_zone)
+      set predicate (is_recharge_zone recharge_zone)
               
       set predicate (piece_at wheel_1 assembly_zone)
       set predicate (piece_at body_car_1 assembly_zone)

--- a/tutorials/docs/terminal_usage.rst
+++ b/tutorials/docs/terminal_usage.rst
@@ -70,7 +70,7 @@ Take into account that the state of the system is at PlanSys2 components, not in
 reopen (or even use several terminals), and the system's state persists. If you want to reset the system, press ``Ctrl-c`` in the terminal
 where you launched PlanSys2, and relaunch it.
 
-  .. code-block::
+  .. code-block:: lisp
 
       ROS2 Planning System console. Type "quit" to finish
       > 
@@ -80,9 +80,9 @@ where you launched PlanSys2, and relaunch it.
 
 1. The first thing is to check the domain that is being used:
 
-  .. code-block::
+  .. code-block:: lisp
 
-      > get domain
+      get domain
 
       ( define ( domain simple )
       ( :requirements :strips :adl :typing :durative-actions :fluents )
@@ -99,24 +99,24 @@ where you launched PlanSys2, and relaunch it.
 
 2. To see what types of instances the model contains, type:
 
-  .. code-block::
+  .. code-block:: lisp
 
-      > get model types
+      get model types
       Types: 2
 	        robot
 	        room
 
 3. Use other variations of ``get model`` to get more information of the domain:
 
-  .. code-block::
+  .. code-block:: lisp
 
-      > get model actions
+      get model actions
       Actions: 0
       	move (durative action)
       	askcharge (durative action)
       	charge (durative action)
       
-      > get model predicates 
+      get model predicates 
       Predicates: 5
       	robot_at
       	connected
@@ -126,14 +126,14 @@ where you launched PlanSys2, and relaunch it.
 
 4. It is also possible to get the details of a predicate or an action:
 
-  .. code-block::
+  .. code-block:: lisp
       
-       > get model predicate robot_at
+       get model predicate robot_at
        Parameters: 2
        	robot - ?robot0
        	room - ?room1
        
-       > get model action move
+       get model action move
        Type: durative-action
        Parameters: 3
        	?0 - robot
@@ -150,35 +150,35 @@ execution of PlanSys2. We could say that it is the static part of the planning i
 The other ingredient is the problem, which contains the instances, grounded (not generic as in 
 the domain, but already with instances) predicates, and goals. We will check that it is empty for now.
 
-  .. code-block::
+  .. code-block:: lisp
 
-       > get problem instances
+       get problem instances
        Instances: 0
        
-       > get problem predicates
+       get problem predicates
        Predicates: 0
        
-       > get problem goal
+       get problem goal
        Goal: 
 
 6. First, let's add instances. If you analyze the domain, we want a robot to be able to move between rooms. For 
 this, the robot must have a battery, and the rooms must be connected. Therefore, we need rooms and a robot:
 
-  .. code-block::
+  .. code-block:: lisp
 
-       > set instance leia robot
-       > set instance entrance room
-       > set instance kitchen room
-       > set instance bedroom room
-       > set instance dinning room
-       > set instance bathroom room
-       > set instance chargingroom room
+       set instance leia robot
+       set instance entrance room
+       set instance kitchen room
+       set instance bedroom room
+       set instance dinning room
+       set instance bathroom room
+       set instance chargingroom room
 
 If no errros, these instances can be checked by typing:
 
-  .. code-block::
+  .. code-block:: lisp
 
-       > get problem instances
+       get problem instances
        Instances: 7
        	leia	robot
        	entrance	room
@@ -190,32 +190,32 @@ If no errros, these instances can be checked by typing:
 
 7. To add predicates, we type:
 
-  .. code-block::
+  .. code-block:: lisp
 
-       > set predicate (connected entrance dinning)
-       > set predicate (connected dinning entrance)
-       > 
-       > set predicate (connected dinning kitchen)
-       > set predicate (connected kitchen dinning)
-       > 
-       > set predicate (connected dinning bedroom)
-       > set predicate (connected bedroom dinning)
-       > 
-       > set predicate (connected bathroom bedroom)
-       > set predicate (connected bedroom bathroom)
-       > 
-       > set predicate (connected chargingroom kitchen)
-       > set predicate (connected kitchen chargingroom)
-       > 
-       > set predicate (charging_point_at chargingroom)
-       > set predicate (battery_low leia)
-       > set predicate (robot_at leia entrance)
+       set predicate (connected entrance dinning)
+       set predicate (connected dinning entrance)
+       
+       set predicate (connected dinning kitchen)
+       set predicate (connected kitchen dinning)
+       
+       set predicate (connected dinning bedroom)
+       set predicate (connected bedroom dinning)
+       
+       set predicate (connected bathroom bedroom)
+       set predicate (connected bedroom bathroom)
+       
+       set predicate (connected chargingroom kitchen)
+       set predicate (connected kitchen chargingroom)
+       
+       set predicate (charging_point_at chargingroom)
+       set predicate (battery_low leia)
+       set predicate (robot_at leia entrance)
 
 Let's check it:
 
-  .. code-block::
+  .. code-block:: lisp
 
-       > get problem predicates
+       get problem predicates
        Predicates: 13
        (connected entrance dinning)
        (connected dinning entrance)
@@ -235,15 +235,15 @@ Let's check it:
 generate the plan. Also, we need to have an objective of our planning, which is a logic expression 
 to end up being true. It is usually a predicate that we want to add to the knowledge:
 
-  .. code-block::
+  .. code-block:: lisp
 
-       > set goal (and(robot_at leia bathroom))
+       set goal (and(robot_at leia bathroom))
 
 9. At this time we can ask that the plan be calculated to obtain this goal:
 
-  .. code-block::
+  .. code-block:: lisp
 
-       > get plan
+       get plan
        plan: 
        0	(askcharge leia entrance chargingroom)	5
        0.001	(charge leia chargingroom)	5
@@ -255,17 +255,17 @@ to end up being true. It is usually a predicate that we want to add to the knowl
 To create the plan, the first thing to do is generate two files: ```/tmp/domain.pddl``` and ```/tmp/problem.pddl```. 
 You can check that they are there from the last planning. In fact, we can run the planner directly by typing in a shell in another terminal:
 
-  .. code-block::
+  .. code-block:: bash
        
        ros2 run popf popf /tmp/domain.pddl /tmp/problem.pddl
 
 10. We can also delete instances, predicates or the goal:
 
-  .. code-block::
+  .. code-block:: lisp
 
-       > remove instance leia
-       > remove predicate (connected entrance dinning)
-       > remove goal 
+       remove instance leia
+       remove predicate (connected entrance dinning)
+       remove goal 
 
 11. What we will not be able to do is execute the plan (we would do it with the ``run`` command) because there is no node 
 running right now that implements the domain actions. We will see that in the next tutorial.


### PR DESCRIPTION
Broken down by commits:

c736a35 changes the code blocks to have the same formatting and it removes the `>` from some of the plansys2 terminal blocks for QOL improvements (it is very time consuming to copy 20 lines of commands 1 by 1.

42f715c adds the missing predicates for the BT Example tutorial (otherwise no plan is found)

495edf4 changes some predicates so that the example makes a bit more sense, otherwise the transport function isn't used for example.

This also closes some of the things that I raised in #4 as possible improvements for the future.