### PR TITLE
Stop videos from autoplaying on page load

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -8,8 +8,8 @@
     <h1 align="center">
       <div>
         <div style="position: relative; padding-bottom: 0%; overflow: hidden; max-width: 100%; height: auto;">
-          <iframe width="450" height="300" src="https://www.youtube.com/embed/SQoN79BBQno?autoplay=1&mute=1" frameborder="1" allowfullscreen></iframe>
-          <iframe width="450" height="300" src="https://www.youtube.com/embed/m8hDw11fTOM?autoplay=1&mute=1" frameborder="1" allowfullscreen></iframe>
+          <iframe width="450" height="300" src="https://www.youtube.com/embed/SQoN79BBQno" frameborder="1" allowfullscreen></iframe>
+          <iframe width="450" height="300" src="https://www.youtube.com/embed/m8hDw11fTOM" frameborder="1" allowfullscreen></iframe>
         </div>
       </div>
     </h1>

--- a/tutorials/docs/bt_actions.rst
+++ b/tutorials/docs/bt_actions.rst
@@ -8,7 +8,7 @@ Implement actions as Behavior Trees
     <h1 align="center">
       <div>
         <div style="position: relative; padding-bottom: 0%; overflow: hidden; max-width: 100%; height: auto;">
-          <iframe width="450" height="300" src="https://www.youtube.com/embed/_oCcIq-TN_0?autoplay=1&mute=1" frameborder="1" allowfullscreen></iframe>
+          <iframe width="450" height="300" src="https://www.youtube.com/embed/_oCcIq-TN_0" frameborder="1" allowfullscreen></iframe>
         </div>
       </div>
     </h1>

--- a/tutorials/docs/controller_example.rst
+++ b/tutorials/docs/controller_example.rst
@@ -8,7 +8,7 @@ Using a planning controller
     <h1 align="center">
       <div>
         <div style="position: relative; padding-bottom: 0%; overflow: hidden; max-width: 100%; height: auto;">
-          <iframe width="450" height="300" src="https://www.youtube.com/embed/fAEGySqefwo?autoplay=1&mute=1" frameborder="1" allowfullscreen></iframe>
+          <iframe width="450" height="300" src="https://www.youtube.com/embed/fAEGySqefwo" frameborder="1" allowfullscreen></iframe>
         </div>
       </div>
     </h1>


### PR DESCRIPTION
Videos shouldn't autoplay by default IMO as it becomes quite annoying when revisiting the page or reloading the browser after a reset etc.

Since they don't autoplay anymore I also removed the muting by default.

let me know what you think @fmrico 