### PR TITLE
Update breathe install version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This folder holds the source and configuration files used to generate the
 Dependencies for Build: 
 * [Sphinx](https://www.sphinx-doc.org/en/master/usage/installation.html)
 * `sudo apt install python3-pip`
-* `pip3 install breathe==4.12.0 sphinx_rtd_theme sphinxcontrib-plantuml`
+* `pip3 install breathe==4.30.0 sphinx_rtd_theme sphinxcontrib-plantuml`
 
 Build the docs locally with `make html` and you'll find the built docs entry point in `_build/html/index.html`.
 


### PR DESCRIPTION
I couldn't build the docs with the previous instructions as it would give an error. Updating the `breathe` version fixed it.

@fmrico 